### PR TITLE
Puppet 4 support

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -42,7 +42,7 @@ define voms::client ($vo = $name, $servers = []  ) {
                    ensure  => directory,
                    owner   => root,
                    group   => root,
-                   mode    => 0755, 
+                   mode    => '0755',
                    recurse => true,
                    purge   => true,
                    require => File['/etc/grid-security/vomsdir']
@@ -52,7 +52,7 @@ define voms::client ($vo = $name, $servers = []  ) {
   File{
      owner => root,
      group => root,
-     mode  => 0644
+     mode  => '0644',
   }
   
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class voms::install (
               ensure  => directory,
               owner   => root,
               group   => root,
-              mode    => 0755,
+              mode    => '0755',
               purge   => true,
               recurse => true,
               force   => true, #because voms::client creates subdirectories, we need force=true to remove them when purging
@@ -23,7 +23,7 @@ class voms::install (
              ensure  => directory,
              owner   => root,
              group   => root,
-             mode    => 0755,
+             mode    => '0755',
              purge   => true,
              recurse => true,
   }                   


### PR DESCRIPTION
With puppet 4 and future parser file modes have to be expressed as strings, or the catalog won't build.
