### PR TITLE
Remove voms.hellasgrid.gr from dteam voms

### DIFF
--- a/manifests/dteam.pp
+++ b/manifests/dteam.pp
@@ -1,11 +1,6 @@
 class voms::dteam {
   voms::client{'dteam':
-      servers => [{ server                   => 'voms.hellasgrid.gr',
-                    port  => '15004',
-                    dn    => '/C=GR/O=HellasGrid/OU=hellasgrid.gr/CN=voms.hellasgrid.gr',
-                    ca_dn => '/C=GR/O=HellasGrid/OU=Certification Authorities/CN=HellasGrid CA 2016'
-                  },
-                  { server                   => 'voms2.hellasgrid.gr',
+      servers => [{ server                   => 'voms2.hellasgrid.gr',
                     port  => '15004',
                     dn    => '/C=GR/O=HellasGrid/OU=hellasgrid.gr/CN=voms2.hellasgrid.gr',
                     ca_dn => '/C=GR/O=HellasGrid/OU=Certification Authorities/CN=HellasGrid CA 2016'


### PR DESCRIPTION
voms.hellasgrid.gr is unreachable and no longer mentioned in documentation
https://operations-portal.egi.eu/vo/view/voname/dteam